### PR TITLE
Migrate udelay.go to time module, which should be portable

### DIFF
--- a/delay/udelay.go
+++ b/delay/udelay.go
@@ -1,26 +1,14 @@
-//go:build linux || darwin
+//go:build darwin || linux
 
 /* delay
-Unix code for timing delay. Only included when OS is linux.
+Unix code for timing delay. Only included when OS is linux or darwin
 */
 package delay
 
 import (
-	"syscall"
+	"time"
 )
 
-// Delay : delay for d nanoseconds
 func Delay(d int64) {
-	var t syscall.Timespec
-	var b syscall.Timespec
-	t.Sec = 0
-	t.Nsec = d
-	//starttime := time.Now()
-	//for i := 0; i < 1000; i++ {
-	_ = syscall.Nanosleep(&t, &b)
-	//	_ = syscall.Times
-	//}
-	//d := time.Since(starttime)
-	//fmt.Println("E", d)
-	//fmt.Println(b)
+	time.Sleep(time.Duration(d))
 }


### PR DESCRIPTION
Fixes #44 